### PR TITLE
Upgrade to Scala 3.3.4 and SBT 1.10.6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Scala-based tax calculation implementation that solves a progressive tax calculation challenge. The codebase consists of:
+
+- **Main Implementation**: `src/main/scala/com/maxondev/TaxCalculator.scala` - Contains the core tax calculation logic using progressive tax brackets
+- **Test Suite**: `src/test/scala/com/maxondev/TaxCalculatorTest.scala` - Comprehensive specs2-based tests
+
+## Architecture
+
+The `TaxCalculator` class implements a progressive tax system with predefined tax brackets stored as a sequence of `TaxForWindow` case classes. The calculation uses recursive pattern matching to apply appropriate tax rates across salary ranges.
+
+## Development Commands
+
+This project uses modern versions: **Scala 3.3.4**, **SBT 1.10.6**, and **specs2 5.5.6**. Compatible with Java 24+.
+
+- **Compile**: `sbt compile`
+- **Run Tests**: `sbt test`
+- **Clean Build**: `sbt clean compile`
+- **Interactive Mode**: `sbt` (then run commands like `test`, `compile`)
+
+## Configuration Notes
+
+- **JVM Options**: Project includes `.sbtopts` and `.jvmopts` files to handle Java 24+ compatibility
+- **Forking**: Tests and runs are forked to properly apply JVM options
+- **Warnings**: Some SBT/Scala runtime warnings may appear on Java 24+ (these are from the toolchain, not project code)
+
+## Testing Framework
+
+Uses specs2 5.5.6 for testing with built-in matchers for floating-point comparisons (`beCloseTo`).
+
+## Key Components
+
+- **TaxForWindow**: Case class defining tax brackets (from, to, percentage)
+- **Progressive Calculation**: Recursive algorithm that applies tax rates cumulatively across brackets
+- **Input Validation**: Requires non-negative salary input

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ name := "TaxCalculator"
 
 version := "1.0.0-SNAPSHOT"
 
-scalaVersion := "2.12.6"
+scalaVersion := "3.3.4"
 
-resolvers ++= Seq("snapshots", "releases").map(Resolver.sonatypeRepo)
+resolvers ++= Resolver.sonatypeOssRepos("snapshots") ++ Resolver.sonatypeOssRepos("releases")
 
-libraryDependencies ++= Seq("org.specs2" %% "specs2-core" % "3.+" % "test")
+libraryDependencies ++= Seq("org.specs2" %% "specs2-core" % "5.5.6" % "test")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.3
+sbt.version = 1.10.6

--- a/src/test/scala/com/maxondev/TaxCalculatorTest.scala
+++ b/src/test/scala/com/maxondev/TaxCalculatorTest.scala
@@ -1,7 +1,6 @@
 package com.maxondev
 
 import org.specs2.mutable.Specification
-import org.specs2.specification.Scope
 
 /**
  * User: maximn
@@ -9,39 +8,35 @@ import org.specs2.specification.Scope
  */
 class TaxCalculatorTest extends Specification {
 
-  trait ctx extends Scope {
-    val calc = new TaxCalculator()
-
-    def beCloseTo(d: Double) = be ~ (d +/- 0.1)
-  }
+  val calc = new TaxCalculator()
 
   "calculator" should {
-    "1st level of tax" in new ctx {
-      calc.calculate(5000) must beCloseTo(500)
+    "1st level of tax" in {
+      calc.calculate(5000) must beCloseTo(500.0, 0.1)
     }
 
-    "2nd level of tax" in new ctx {
-      calc.calculate(5800) must beCloseTo(609.2)
+    "2nd level of tax" in {
+      calc.calculate(5800) must beCloseTo(609.2, 0.1)
     }
 
-    "last level of tax" in new ctx {
-      calc.calculate(50000) must beCloseTo(15068.1)
+    "last level of tax" in {
+      calc.calculate(50000) must beCloseTo(15068.1, 0.1)
     }
 
-    "fail on a negative input" in new ctx {
+    "fail on a negative input" in {
       calc.calculate(-1) must throwA[IllegalArgumentException]
     }
 
-    "be 0 for 0 salary" in new ctx {
-      calc.calculate(0) must be_===(0)
+    "be 0 for 0 salary" in {
+      calc.calculate(0) must beEqualTo(0.0)
     }
 
-    "exactly upper bound of a tax level" in new ctx {
-      calc.calculate(8660) must beCloseTo(1009.6)
+    "exactly upper bound of a tax level" in {
+      calc.calculate(8660) must beCloseTo(1009.6, 0.1)
     }
 
-    "exactly lower bound of a tax level" in new ctx {
-      calc.calculate(8661) must beCloseTo(1009.83)
+    "exactly lower bound of a tax level" in {
+      calc.calculate(8661) must beCloseTo(1009.83, 0.1)
     }
   }
 }


### PR DESCRIPTION
## Summary
- Upgrade Scala from 2.12.6 to 3.3.4 for better performance and language features
- Update SBT from 1.2.3 to 1.10.6 for Java 24+ compatibility
- Modernize specs2 testing framework to version 5.5.6
- Fix deprecated syntax and improve project configuration

## Test plan
- [x] All existing tests pass with new versions
- [x] Project compiles successfully with Scala 3
- [x] SBT commands work correctly
- [x] Tax calculation logic remains unchanged and accurate